### PR TITLE
fix: upgrade module to be tf 0.12 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,62 +6,68 @@ provision a VPC on AWS.
 
 In particular, it does the following:
 
-- Provisions (optional) public, private, database and intra subnets
+- Provisions (optional) public, private, database, intra and redshift subnets
 - One NAT gateway per AZ
 - Removes all default security group and ACL rules
 - Provides sane ACL rules for network access
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | >= 2.0 |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| additional_allowed_cidr_blocks | Additional 'safe' CIDR blocks for internal traffic | string | `<list>` | no |
-| database_subnets | List of CIDRs for database subnets | string | `<list>` | no |
-| eip_count | Number of EIP for the gateways. This should be eqaual to the number of AZs if you have any private subnets | string | `3` | no |
-| elasticache_subnets | Lsit of CIDRs for Elasticache subnets | string | `<list>` | no |
-| enable_dynamodb_endpoint | Should be true if you want to provision a DynamoDB endpoint to the VPC | string | `false` | no |
-| enable_s3_endpoint | Should be true if you want to provision an S3 endpoint to the VPC | string | `false` | no |
-| ephemeral_from | Lower end of the port range for ephemeral traffic | string | `1024` | no |
-| ephemeral_to | Lower end of the port range for ephemeral traffic | string | `65535` | no |
-| intra_subnets | List of CIDRs for intra subnets | string | `<list>` | no |
-| private_subnets | List of CIDRs for private subnets | string | `<list>` | no |
-| public_subnets | List of CIDRs for public subnets | string | `<list>` | no |
-| redshift_subnets | Lsit of CIDRs for Redshift subnets | string | `<list>` | no |
-| tags | A map of tags to add to all resources | string | `<map>` | no |
-| vpc_cidr | CIDR for the VPC | string | - | yes |
-| vpc_name | Name of the VPC | string | - | yes |
+|------|-------------|------|---------|:-----:|
+| additional\_allowed\_cidr\_blocks | Additional 'safe' CIDR blocks for internal traffic | `list(string)` | `[]` | no |
+| database\_subnets | List of CIDRs for database subnets | `list(string)` | `[]` | no |
+| eip\_count | Number of EIP for the gateways. This should be eqaual to the number of AZs if you have any private subnets | `number` | `3` | no |
+| elasticache\_subnets | List of CIDRs for Elasticache subnets | `list(string)` | `[]` | no |
+| enable\_dynamodb\_endpoint | Should be true if you want to provision a DynamoDB endpoint to the VPC | `bool` | `false` | no |
+| enable\_s3\_endpoint | Should be true if you want to provision an S3 endpoint to the VPC | `bool` | `false` | no |
+| ephemeral\_from | Lower end of the port range for ephemeral traffic | `number` | `1024` | no |
+| ephemeral\_to | Lower end of the port range for ephemeral traffic | `number` | `65535` | no |
+| intra\_subnets | List of CIDRs for intra subnets | `list(string)` | `[]` | no |
+| private\_subnets | List of CIDRs for private subnets | `list(string)` | `[]` | no |
+| public\_subnets | List of CIDRs for public subnets | `list(string)` | `[]` | no |
+| redshift\_subnets | List of CIDRs for Redshift subnets | `list(string)` | `[]` | no |
+| tags | A map of tags to add to all resources | `map(string)` | <pre>{<br>  "Terraform": "true"<br>}<br></pre> | no |
+| vpc\_cidr | CIDR for the VPC | `string` | n/a | yes |
+| vpc\_name | Name of the VPC | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| database_acl_id | ACL ID of the database subnets |
-| elasticache_route_table_ids | List of IDs of elasticache route tables |
-| elasticache_subnet_group | ID of elasticache subnet group |
-| elasticache_subnet_group_name | Name of elasticache subnet group |
-| elasticache_subnets | List of IDs of elasticache subnets |
-| elasticache_subnets_cidr_blocks | List of cidr_blocks of elasticache subnets |
-| intra_acl_id | ACL ID of the intra subnets |
-| intra_subnets_cidr_blocks | List of cidr_blocks of intra subnets |
-| private_acl_id | ACL ID of the private subnets |
-| private_subnets_cidr_blocks | List of cidr_blocks of private subnets |
-| public_acl_id | ACL ID of the public subnets |
-| public_subnets_cidr_blocks | List of cidr_blocks of public subnets |
-| redshift_route_table_ids | List of IDs of redshift route tables |
-| redshift_subnet_group | ID of redshift subnet group |
-| redshift_subnets | List of IDs of redshift subnets |
-| redshift_subnets_cidr_blocks | List of cidr_blocks of redshift subnets |
-| vpc_azs | The AZs in the region the VPC belongs to |
-| vpc_cidr_block | The CIDR block of the VPC |
-| vpc_database_subnet_group | ID of database subnet group |
-| vpc_database_subnets | List of IDs of database subnets |
-| vpc_database_subnets_cidr_blocks | List of cidr_blocks of database subnets |
-| vpc_id | The ID of the VPC |
-| vpc_intra_subnets | 'Intra' subnets for the VPC |
-| vpc_nat_eip_ids | EIP for the NAT gateway in the VPC |
-| vpc_nat_eip_public | Public address for the EIP on the NAT Gateway |
-| vpc_private_route_table_ids | List of IDs of private route tables |
-| vpc_private_subnets | Private subnets for the VPC |
-| vpc_public_route_table_ids | The IDs of the public route tables |
-| vpc_public_subnets | Public subnets for the VPC |
-| vpc_region | The region the VPC belongs to |
+| database\_acl\_id | ACL ID of the database subnets |
+| elasticache\_route\_table\_ids | List of IDs of elasticache route tables |
+| elasticache\_subnet\_group | ID of elasticache subnet group |
+| elasticache\_subnet\_group\_name | Name of elasticache subnet group |
+| elasticache\_subnets | List of IDs of elasticache subnets |
+| elasticache\_subnets\_cidr\_blocks | List of cidr\_blocks of elasticache subnets |
+| intra\_acl\_id | ACL ID of the intra subnets |
+| intra\_subnets\_cidr\_blocks | List of cidr\_blocks of intra subnets |
+| private\_acl\_id | ACL ID of the private subnets |
+| private\_subnets\_cidr\_blocks | List of cidr\_blocks of private subnets |
+| public\_acl\_id | ACL ID of the public subnets |
+| public\_subnets\_cidr\_blocks | List of cidr\_blocks of public subnets |
+| redshift\_route\_table\_ids | List of IDs of redshift route tables |
+| redshift\_subnet\_group | ID of redshift subnet group |
+| redshift\_subnets | List of IDs of redshift subnets |
+| redshift\_subnets\_cidr\_blocks | List of cidr\_blocks of redshift subnets |
+| vpc\_azs | The AZs in the region the VPC belongs to |
+| vpc\_cidr\_block | The CIDR block of the VPC |
+| vpc\_database\_subnet\_group | ID of database subnet group |
+| vpc\_database\_subnets | List of IDs of database subnets |
+| vpc\_database\_subnets\_cidr\_blocks | List of cidr\_blocks of database subnets |
+| vpc\_id | The ID of the VPC |
+| vpc\_intra\_subnets | 'Intra' subnets for the VPC |
+| vpc\_nat\_eip\_ids | EIP for the NAT gateway in the VPC |
+| vpc\_nat\_eip\_public | Public address for the EIP on the NAT Gateway |
+| vpc\_private\_route\_table\_ids | List of IDs of private route tables |
+| vpc\_private\_subnets | Private subnets for the VPC |
+| vpc\_public\_route\_table\_ids | The IDs of the public route tables |
+| vpc\_public\_subnets | Public subnets for the VPC |
+| vpc\_region | The region the VPC belongs to |

--- a/main.tf
+++ b/main.tf
@@ -1,79 +1,75 @@
-data "aws_availability_zones" "available" {}
+terraform {
+  required_version = ">= 0.12"
 
-data "aws_region" "current" {
-  current = true
+  required_providers {
+    aws = ">= 2.0"
+  }
 }
 
+data "aws_availability_zones" "available" {}
+
+data "aws_region" "current" {}
+
 resource "aws_eip" "nat" {
-  count = "${var.eip_count}"
+  count = var.eip_count
 
   vpc  = true
-  tags = "${merge(var.tags, map("Name", "${var.vpc_name} NAT Gateway"))}"
+  tags = merge(var.tags, { Name = "${var.vpc_name} NAT Gateway" })
 }
 
 module "vpc" {
-  source = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v1.41.0"
+  source = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v2.23.0"
 
-  name = "${var.vpc_name}"
-  cidr = "${var.vpc_cidr}"
+  name = var.vpc_name
+  cidr = var.vpc_cidr
 
-  azs                 = ["${data.aws_availability_zones.available.names}"]
-  public_subnets      = ["${var.public_subnets}"]
-  private_subnets     = ["${var.private_subnets}"]
-  database_subnets    = ["${var.database_subnets}"]
-  redshift_subnets    = ["${var.redshift_subnets}"]
-  elasticache_subnets = ["${var.elasticache_subnets}"]
+  azs                 = data.aws_availability_zones.available.names
+  public_subnets      = var.public_subnets
+  private_subnets     = var.private_subnets
+  database_subnets    = var.database_subnets
+  redshift_subnets    = var.redshift_subnets
+  elasticache_subnets = var.elasticache_subnets
 
   # Intra subnet with no internet access: https://github.com/terraform-aws-modules/terraform-aws-vpc#private-versus-intra-subnets
-  intra_subnets = ["${var.intra_subnets}"]
+  intra_subnets = var.intra_subnets
 
   # One gateway per AZ: https://github.com/terraform-aws-modules/terraform-aws-vpc#nat-gateway-scenarios
-  enable_nat_gateway     = "${var.eip_count > 0 ? "true" : "false"}"
+  enable_nat_gateway     = var.eip_count > 0 ? "true" : "false"
   single_nat_gateway     = false
-  one_nat_gateway_per_az = "${var.eip_count > 0 ? "true" : "false"}"
+  one_nat_gateway_per_az = var.eip_count > 0 ? "true" : "false"
 
   reuse_nat_ips       = true
-  external_nat_ip_ids = ["${aws_eip.nat.*.id}"]
+  external_nat_ip_ids = aws_eip.nat.*.id
 
   enable_vpn_gateway   = false
   enable_dns_hostnames = true
 
-  enable_s3_endpoint       = "${var.eip_count > 0 ? var.enable_s3_endpoint: "false"}"
-  enable_dynamodb_endpoint = "${var.eip_count > 0 ? var.enable_dynamodb_endpoint: "false"}"
+  enable_s3_endpoint       = var.eip_count > 0 ? var.enable_s3_endpoint : "false"
+  enable_dynamodb_endpoint = var.eip_count > 0 ? var.enable_dynamodb_endpoint : "false"
 
-  tags = "${var.tags}"
+  tags = var.tags
 }
 
 # Remove all default rules from the default security group
 resource "aws_default_security_group" "default" {
-  vpc_id = "${module.vpc.vpc_id}"
-  tags   = "${merge(var.tags, map("Name", "${var.vpc_name} Default Security Group"))}"
-}
-
-# For some reason, ${module.vpc.default_vpc_default_network_acl_id} is empty
-data "aws_network_acls" "default" {
-  vpc_id = "${module.vpc.vpc_id}"
-
-  filter {
-    name   = "default"
-    values = ["true"]
-  }
+  vpc_id = module.vpc.vpc_id
+  tags   = merge(var.tags, { Name = "${var.vpc_name} Default Security Group" })
 }
 
 # Remove all rules from the default network ACL. That means all subnets, by default,
 # `DENY` for all incoming and outgoing traffic
 resource "aws_default_network_acl" "default" {
-  default_network_acl_id = "${data.aws_network_acls.default.ids[0]}"
+  default_network_acl_id = module.vpc.default_network_acl_id
 
-  tags = "${merge(var.tags, map("Name", "${var.vpc_name} Default ACLs"))}"
+  tags = merge(var.tags, { Name = "${var.vpc_name} Default ACLs" })
 
   lifecycle {
-    ignore_changes = ["subnet_ids"]
+    ignore_changes = [subnet_ids]
   }
 }
 
 locals {
-  internal_cidrs = ["${distinct(concat(list(var.vpc_cidr), var.additional_allowed_cidr_blocks))}"]
+  internal_cidrs = distinct(concat([var.vpc_cidr], var.additional_allowed_cidr_blocks))
 }
 
 ###########################################################
@@ -81,14 +77,14 @@ locals {
 # See https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Appendix_NACLs.html
 ###########################################################
 resource "aws_network_acl" "public" {
-  vpc_id     = "${module.vpc.vpc_id}"
-  subnet_ids = ["${module.vpc.public_subnets}"]
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.public_subnets
 
-  tags = "${merge(var.tags, map("Name", "${var.vpc_name} Public ACLs"))}"
+  tags = merge(var.tags, { Name = "${var.vpc_name} Public ACLs" })
 }
 
 resource "aws_network_acl_rule" "public_outgoing" {
-  network_acl_id = "${aws_network_acl.public.id}"
+  network_acl_id = aws_network_acl.public.id
 
   rule_number = "100"
   egress      = true
@@ -98,18 +94,18 @@ resource "aws_network_acl_rule" "public_outgoing" {
 }
 
 resource "aws_network_acl_rule" "public_incoming_internal" {
-  count          = "${length(local.internal_cidrs)}"
-  network_acl_id = "${aws_network_acl.public.id}"
+  count          = length(local.internal_cidrs)
+  network_acl_id = aws_network_acl.public.id
 
-  rule_number = "${100 + count.index}"
+  rule_number = 100 + count.index
   egress      = false
   protocol    = "all"
   rule_action = "allow"
-  cidr_block  = "${element(local.internal_cidrs, count.index)}"
+  cidr_block  = local.internal_cidrs[count.index]
 }
 
 resource "aws_network_acl_rule" "public_incoming_http" {
-  network_acl_id = "${aws_network_acl.public.id}"
+  network_acl_id = aws_network_acl.public.id
 
   rule_number = "200"
   egress      = false
@@ -121,7 +117,7 @@ resource "aws_network_acl_rule" "public_incoming_http" {
 }
 
 resource "aws_network_acl_rule" "public_incoming_https" {
-  network_acl_id = "${aws_network_acl.public.id}"
+  network_acl_id = aws_network_acl.public.id
 
   rule_number = "201"
   egress      = false
@@ -133,14 +129,14 @@ resource "aws_network_acl_rule" "public_incoming_https" {
 }
 
 resource "aws_network_acl_rule" "public_incoming_ephemeral" {
-  network_acl_id = "${aws_network_acl.public.id}"
+  network_acl_id = aws_network_acl.public.id
 
   rule_number = "202"
   egress      = false
   protocol    = "tcp"
   rule_action = "allow"
-  from_port   = "${var.ephemeral_from}"
-  to_port     = "${var.ephemeral_to}"
+  from_port   = var.ephemeral_from
+  to_port     = var.ephemeral_to
   cidr_block  = "0.0.0.0/0"
 }
 
@@ -148,14 +144,14 @@ resource "aws_network_acl_rule" "public_incoming_ephemeral" {
 # ACL Rules for "private" submets
 ###########################################################
 resource "aws_network_acl" "private" {
-  vpc_id     = "${module.vpc.vpc_id}"
-  subnet_ids = ["${module.vpc.private_subnets}"]
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
 
-  tags = "${merge(var.tags, map("Name", "${var.vpc_name} Private ACLs"))}"
+  tags = merge(var.tags, { Name = "${var.vpc_name} Private ACLs" })
 }
 
 resource "aws_network_acl_rule" "private_outgoing" {
-  network_acl_id = "${aws_network_acl.private.id}"
+  network_acl_id = aws_network_acl.private.id
 
   rule_number = "100"
   egress      = true
@@ -165,25 +161,25 @@ resource "aws_network_acl_rule" "private_outgoing" {
 }
 
 resource "aws_network_acl_rule" "private_incoming_internal" {
-  count          = "${length(local.internal_cidrs)}"
-  network_acl_id = "${aws_network_acl.private.id}"
+  count          = length(local.internal_cidrs)
+  network_acl_id = aws_network_acl.private.id
 
-  rule_number = "${200 + count.index}"
+  rule_number = 200 + count.index
   egress      = false
   protocol    = "all"
   rule_action = "allow"
-  cidr_block  = "${element(local.internal_cidrs, count.index)}"
+  cidr_block  = local.internal_cidrs[count.index]
 }
 
 resource "aws_network_acl_rule" "private_incoming_ephemeral" {
-  network_acl_id = "${aws_network_acl.private.id}"
+  network_acl_id = aws_network_acl.private.id
 
   rule_number = "101"
   egress      = false
   protocol    = "tcp"
   rule_action = "allow"
-  from_port   = "${var.ephemeral_from}"
-  to_port     = "${var.ephemeral_to}"
+  from_port   = var.ephemeral_from
+  to_port     = var.ephemeral_to
   cidr_block  = "0.0.0.0/0"
 }
 
@@ -191,126 +187,126 @@ resource "aws_network_acl_rule" "private_incoming_ephemeral" {
 # ACL Rules for "database" submets
 ###########################################################
 resource "aws_network_acl" "database" {
-  vpc_id     = "${module.vpc.vpc_id}"
-  subnet_ids = ["${module.vpc.database_subnets}"]
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.database_subnets
 
-  tags = "${merge(var.tags, map("Name", "${var.vpc_name} Database ACLs"))}"
+  tags = merge(var.tags, { Name = "${var.vpc_name} Database ACLs" })
 }
 
 resource "aws_network_acl_rule" "database_incoming_internal" {
-  count          = "${length(local.internal_cidrs)}"
-  network_acl_id = "${aws_network_acl.database.id}"
+  count          = length(local.internal_cidrs)
+  network_acl_id = aws_network_acl.database.id
 
-  rule_number = "${200 + count.index}"
+  rule_number = 200 + count.index
   egress      = false
   protocol    = "all"
   rule_action = "allow"
-  cidr_block  = "${element(local.internal_cidrs, count.index)}"
+  cidr_block  = local.internal_cidrs[count.index]
 }
 
 resource "aws_network_acl_rule" "database_outgoing_internal" {
-  count          = "${length(local.internal_cidrs)}"
-  network_acl_id = "${aws_network_acl.database.id}"
+  count          = length(local.internal_cidrs)
+  network_acl_id = aws_network_acl.database.id
 
-  rule_number = "${200 + count.index}"
+  rule_number = 200 + count.index
   egress      = true
   protocol    = "all"
   rule_action = "allow"
-  cidr_block  = "${element(local.internal_cidrs, count.index)}"
+  cidr_block  = local.internal_cidrs[count.index]
 }
 
 ###########################################################
 # ACL Rules for "intra" submets
 ###########################################################
 resource "aws_network_acl" "intra" {
-  vpc_id     = "${module.vpc.vpc_id}"
-  subnet_ids = ["${module.vpc.intra_subnets}"]
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.intra_subnets
 
-  tags = "${merge(var.tags, map("Name", "${var.vpc_name} Intra ACLs"))}"
+  tags = merge(var.tags, { Name = "${var.vpc_name} Intra ACLs" })
 }
 
 resource "aws_network_acl_rule" "intra_incoming_internal" {
-  count          = "${length(local.internal_cidrs)}"
-  network_acl_id = "${aws_network_acl.intra.id}"
+  count          = length(local.internal_cidrs)
+  network_acl_id = aws_network_acl.intra.id
 
-  rule_number = "${200 + count.index}"
+  rule_number = 200 + count.index
   egress      = false
   protocol    = "all"
   rule_action = "allow"
-  cidr_block  = "${element(local.internal_cidrs, count.index)}"
+  cidr_block  = local.internal_cidrs[count.index]
 }
 
 resource "aws_network_acl_rule" "intra_outgoing_internal" {
-  count          = "${length(local.internal_cidrs)}"
-  network_acl_id = "${aws_network_acl.intra.id}"
+  count          = length(local.internal_cidrs)
+  network_acl_id = aws_network_acl.intra.id
 
-  rule_number = "${200 + count.index}"
+  rule_number = 200 + count.index
   egress      = true
   protocol    = "all"
   rule_action = "allow"
-  cidr_block  = "${element(local.internal_cidrs, count.index)}"
+  cidr_block  = local.internal_cidrs[count.index]
 }
 
 ###########################################################
 # ACL Rules for "elasticache" submets
 ###########################################################
 resource "aws_network_acl" "elasticache" {
-  vpc_id     = "${module.vpc.vpc_id}"
-  subnet_ids = ["${module.vpc.elasticache_subnets}"]
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.elasticache_subnets
 
-  tags = "${merge(var.tags, map("Name", "${var.vpc_name} ElastiCache ACLs"))}"
+  tags = merge(var.tags, { Name = "${var.vpc_name} ElastiCache ACLs" })
 }
 
 resource "aws_network_acl_rule" "elasticache_incoming_internal" {
-  count          = "${length(local.internal_cidrs)}"
-  network_acl_id = "${aws_network_acl.elasticache.id}"
+  count          = length(local.internal_cidrs)
+  network_acl_id = aws_network_acl.elasticache.id
 
-  rule_number = "${200 + count.index}"
+  rule_number = 200 + count.index
   egress      = false
   protocol    = "all"
   rule_action = "allow"
-  cidr_block  = "${element(local.internal_cidrs, count.index)}"
+  cidr_block  = local.internal_cidrs[count.index]
 }
 
 resource "aws_network_acl_rule" "elasticache_outgoing_internal" {
-  count          = "${length(local.internal_cidrs)}"
-  network_acl_id = "${aws_network_acl.elasticache.id}"
+  count          = length(local.internal_cidrs)
+  network_acl_id = aws_network_acl.elasticache.id
 
-  rule_number = "${200 + count.index}"
+  rule_number = 200 + count.index
   egress      = true
   protocol    = "all"
   rule_action = "allow"
-  cidr_block  = "${element(local.internal_cidrs, count.index)}"
+  cidr_block  = local.internal_cidrs[count.index]
 }
 
 ###########################################################
 # ACL Rules for "redshift" submets
 ###########################################################
 resource "aws_network_acl" "redshift" {
-  vpc_id     = "${module.vpc.vpc_id}"
-  subnet_ids = ["${module.vpc.redshift_subnets}"]
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.redshift_subnets
 
-  tags = "${merge(var.tags, map("Name", "${var.vpc_name} RedShift ACLs"))}"
+  tags = merge(var.tags, { Name = "${var.vpc_name} RedShift ACLs" })
 }
 
 resource "aws_network_acl_rule" "redshift_incoming_internal" {
-  count          = "${length(local.internal_cidrs)}"
-  network_acl_id = "${aws_network_acl.redshift.id}"
+  count          = length(local.internal_cidrs)
+  network_acl_id = aws_network_acl.redshift.id
 
-  rule_number = "${200 + count.index}"
+  rule_number = 200 + count.index
   egress      = false
   protocol    = "all"
   rule_action = "allow"
-  cidr_block  = "${element(local.internal_cidrs, count.index)}"
+  cidr_block  = local.internal_cidrs[count.index]
 }
 
 resource "aws_network_acl_rule" "redshift_outgoing_internal" {
-  count          = "${length(local.internal_cidrs)}"
-  network_acl_id = "${aws_network_acl.redshift.id}"
+  count          = length(local.internal_cidrs)
+  network_acl_id = aws_network_acl.redshift.id
 
-  rule_number = "${200 + count.index}"
+  rule_number = 200 + count.index
   egress      = true
   protocol    = "all"
   rule_action = "allow"
-  cidr_block  = "${element(local.internal_cidrs, count.index)}"
+  cidr_block  = local.internal_cidrs[count.index]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,149 +1,149 @@
 output "vpc_id" {
   description = "The ID of the VPC"
-  value       = "${module.vpc.vpc_id}"
+  value       = module.vpc.vpc_id
 }
 
 output "vpc_cidr_block" {
   description = "The CIDR block of the VPC"
-  value       = "${module.vpc.vpc_cidr_block}"
+  value       = module.vpc.vpc_cidr_block
 }
 
 output "vpc_public_subnets" {
   description = "Public subnets for the VPC"
-  value       = "${module.vpc.public_subnets}"
+  value       = module.vpc.public_subnets
 }
 
 output "public_subnets_cidr_blocks" {
   description = "List of cidr_blocks of public subnets"
-  value       = "${module.vpc.public_subnets_cidr_blocks}"
+  value       = module.vpc.public_subnets_cidr_blocks
 }
 
 output "vpc_private_subnets" {
   description = "Private subnets for the VPC"
-  value       = "${module.vpc.private_subnets}"
+  value       = module.vpc.private_subnets
 }
 
 output "private_subnets_cidr_blocks" {
   description = "List of cidr_blocks of private subnets"
-  value       = "${module.vpc.private_subnets_cidr_blocks}"
+  value       = module.vpc.private_subnets_cidr_blocks
 }
 
 output "vpc_intra_subnets" {
   description = "'Intra' subnets for the VPC"
-  value       = "${module.vpc.intra_subnets}"
+  value       = module.vpc.intra_subnets
 }
 
 output "intra_subnets_cidr_blocks" {
   description = "List of cidr_blocks of intra subnets"
-  value       = "${module.vpc.intra_subnets_cidr_blocks}"
+  value       = module.vpc.intra_subnets_cidr_blocks
 }
 
 output "vpc_database_subnets" {
   description = "List of IDs of database subnets"
-  value       = "${module.vpc.database_subnets}"
+  value       = module.vpc.database_subnets
 }
 
 output "vpc_database_subnets_cidr_blocks" {
   description = "List of cidr_blocks of database subnets"
-  value       = "${module.vpc.database_subnets_cidr_blocks}"
+  value       = module.vpc.database_subnets_cidr_blocks
 }
 
 output "vpc_database_subnet_group" {
   description = "ID of database subnet group"
-  value       = "${module.vpc.database_subnet_group}"
+  value       = module.vpc.database_subnet_group
 }
 
 output "vpc_public_route_table_ids" {
   description = "The IDs of the public route tables"
-  value       = "${module.vpc.public_route_table_ids}"
+  value       = module.vpc.public_route_table_ids
 }
 
 output "vpc_private_route_table_ids" {
   description = "List of IDs of private route tables"
-  value       = "${module.vpc.private_route_table_ids}"
+  value       = module.vpc.private_route_table_ids
 }
 
 output "vpc_region" {
   description = "The region the VPC belongs to"
-  value       = "${data.aws_region.current.name}"
+  value       = data.aws_region.current.name
 }
 
 output "vpc_azs" {
   description = "The AZs in the region the VPC belongs to"
-  value       = ["${data.aws_availability_zones.available.names}"]
+  value       = data.aws_availability_zones.available.names
 }
 
 output "vpc_nat_eip_ids" {
   description = "EIP for the NAT gateway in the VPC"
-  value       = ["${aws_eip.nat.*.id}"]
+  value       = aws_eip.nat.*.id
 }
 
 output "vpc_nat_eip_public" {
   description = "Public address for the EIP on the NAT Gateway"
-  value       = ["${aws_eip.nat.*.public_ip}"]
+  value       = aws_eip.nat.*.public_ip
 }
 
 output "public_acl_id" {
   description = "ACL ID of the public subnets"
-  value       = "${aws_network_acl.public.id}"
+  value       = aws_network_acl.public.id
 }
 
 output "private_acl_id" {
   description = "ACL ID of the private subnets"
-  value       = "${aws_network_acl.private.id}"
+  value       = aws_network_acl.private.id
 }
 
 output "database_acl_id" {
   description = "ACL ID of the database subnets"
-  value       = "${aws_network_acl.database.id}"
+  value       = aws_network_acl.database.id
 }
 
 output "intra_acl_id" {
   description = "ACL ID of the intra subnets"
-  value       = "${aws_network_acl.intra.id}"
+  value       = aws_network_acl.intra.id
 }
 
 output "redshift_route_table_ids" {
   description = "List of IDs of redshift route tables"
-  value       = "${module.vpc.redshift_route_table_ids}"
+  value       = module.vpc.redshift_route_table_ids
 }
 
 output "redshift_subnet_group" {
   description = "ID of redshift subnet group"
-  value       = "${module.vpc.redshift_subnet_group}"
+  value       = module.vpc.redshift_subnet_group
 }
 
 output "redshift_subnets" {
   description = "List of IDs of redshift subnets"
-  value       = "${module.vpc.redshift_subnets}"
+  value       = module.vpc.redshift_subnets
 }
 
 output "redshift_subnets_cidr_blocks" {
   description = "List of cidr_blocks of redshift subnets"
-  value       = "${module.vpc.redshift_subnets_cidr_blocks}"
+  value       = module.vpc.redshift_subnets_cidr_blocks
 }
 
 output "elasticache_route_table_ids" {
   description = "List of IDs of elasticache route tables"
-  value       = "${module.vpc.elasticache_route_table_ids}"
+  value       = module.vpc.elasticache_route_table_ids
 }
 
 output "elasticache_subnet_group" {
   description = "ID of elasticache subnet group"
-  value       = "${module.vpc.elasticache_subnet_group}"
+  value       = module.vpc.elasticache_subnet_group
 }
 
 output "elasticache_subnet_group_name" {
   description = "Name of elasticache subnet group"
-  value       = "${module.vpc.elasticache_subnet_group_name}"
+  value       = module.vpc.elasticache_subnet_group_name
 }
 
 output "elasticache_subnets" {
   description = "List of IDs of elasticache subnets"
-  value       = "${module.vpc.elasticache_subnets}"
+  value       = module.vpc.elasticache_subnets
 }
 
 output "elasticache_subnets_cidr_blocks" {
   description = "List of cidr_blocks of elasticache subnets"
-  value       = "${module.vpc.elasticache_subnets_cidr_blocks}"
+  value       = module.vpc.elasticache_subnets_cidr_blocks
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,11 @@
 variable "vpc_name" {
   description = "Name of the VPC"
+  type        = string
 }
 
 variable "vpc_cidr" {
   description = "CIDR for the VPC"
+  type        = string
 }
 
 ################################################
@@ -11,31 +13,37 @@ variable "vpc_cidr" {
 ################################################
 variable "public_subnets" {
   description = "List of CIDRs for public subnets"
+  type        = list(string)
   default     = []
 }
 
 variable "private_subnets" {
   description = "List of CIDRs for private subnets"
+  type        = list(string)
   default     = []
 }
 
 variable "database_subnets" {
   description = "List of CIDRs for database subnets"
+  type        = list(string)
   default     = []
 }
 
 variable "intra_subnets" {
   description = "List of CIDRs for intra subnets"
+  type        = list(string)
   default     = []
 }
 
 variable "redshift_subnets" {
-  description = "Lsit of CIDRs for Redshift subnets"
+  description = "List of CIDRs for Redshift subnets"
+  type        = list(string)
   default     = []
 }
 
 variable "elasticache_subnets" {
-  description = "Lsit of CIDRs for Elasticache subnets"
+  description = "List of CIDRs for Elasticache subnets"
+  type        = list(string)
   default     = []
 }
 
@@ -46,6 +54,7 @@ variable "eip_count" {
 
 variable "additional_allowed_cidr_blocks" {
   description = "Additional 'safe' CIDR blocks for internal traffic"
+  type        = list(string)
   default     = []
 }
 
@@ -71,6 +80,7 @@ variable "enable_dynamodb_endpoint" {
 
 variable "tags" {
   description = "A map of tags to add to all resources"
+  type        = map(string)
 
   default = {
     Terraform = "true"


### PR DESCRIPTION
Simplify `aws_default_network_acl` to use
`module.vpc.default_network_acl_id`.

BREAKING CHANGE: No longer support below tf 0.12.